### PR TITLE
docs: add-issue-templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,22 +2,24 @@
 name: Bug Report
 about: Bug Report Template
 title: "[BUG] ..."
-
 ---
 
-**Bug Description**
+**Description:**
+
 ...
 
-**Steps to Reproduction:**
+**Steps to reproduce:**
 1. ...
 
-**Expected behavior**
+**Expected behavior:**
+
 ...
 
-**System Information:**
-- Type of Device: [e.g. desktop, phone, raspy]
-- OS: [e.g. linux, windows]
- - Browser [e.g. chrome, safari]
+**System information:**
+- Type of device: [e.g. Desktop, Phone, Raspy]
+- OS: [e.g. Linux, Windows]
+- Browser [e.g. Chrome, Firefox]
 
-**Additional information, media**
+**Additional information, media:**
+
 ...

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: Bug Report Template
-title: "[BUG] ..."
+title: "bug: ..."
 ---
 
 **Description:**

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report
+about: Bug Report Template
+title: "[BUG]"
+labels: ''
+assignees: ''
+
+---
+
+**Bug Description**
+...
+
+**Steps to Reproduction:**
+1. ...
+
+**Expected behavior**
+...
+
+**System Information:**
+- Type of Device: [e.g. desktop, phone, raspy]
+- OS: [e.g. linux, windows]
+ - Browser [e.g. chrome, safari]
+
+**Additional information, media**
+...

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,9 +1,7 @@
 ---
 name: Bug Report
 about: Bug Report Template
-title: "[BUG]"
-labels: ''
-assignees: ''
+title: "[BUG] ..."
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/new-feature.md
+++ b/.github/ISSUE_TEMPLATE/new-feature.md
@@ -2,17 +2,18 @@
 name: New Feature
 about: New Feature Template
 title: "[FEAT] ..."
-
 ---
 
-**Feature Description**
+**Description**
+
 ...
 
 **Is blocked by Issue/s:**
 - ...
 
 **Tasks:**
-- [] ...
+- [ ] ...
 
-** Additional information, media,...**
+**Additional information, media,...**
+
 ...

--- a/.github/ISSUE_TEMPLATE/new-feature.md
+++ b/.github/ISSUE_TEMPLATE/new-feature.md
@@ -1,9 +1,7 @@
 ---
 name: New Feature
 about: New Feature Template
-title: "[FEAT]"
-labels: ''
-assignees: ''
+title: "[FEAT] ..."
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/new-feature.md
+++ b/.github/ISSUE_TEMPLATE/new-feature.md
@@ -1,0 +1,20 @@
+---
+name: New Feature
+about: New Feature Template
+title: "[FEAT]"
+labels: ''
+assignees: ''
+
+---
+
+**Feature Description**
+...
+
+**Is blocked by Issue/s:**
+- ...
+
+**Tasks:**
+- [] ...
+
+** Additional information, media,...**
+...

--- a/.github/ISSUE_TEMPLATE/new-feature.md
+++ b/.github/ISSUE_TEMPLATE/new-feature.md
@@ -1,7 +1,7 @@
 ---
 name: New Feature
 about: New Feature Template
-title: "[FEAT] ..."
+title: "feat: ..."
 ---
 
 **Description**

--- a/.github/ISSUE_TEMPLATE/new-pull-request.md
+++ b/.github/ISSUE_TEMPLATE/new-pull-request.md
@@ -1,9 +1,7 @@
 ---
 name: New Pull Request
 about: Pull Request Template
-title: "[PR]"
-labels: ''
-assignees: ''
+title: "[PR] ..."
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/new-pull-request.md
+++ b/.github/ISSUE_TEMPLATE/new-pull-request.md
@@ -1,7 +1,6 @@
 ---
 name: New Pull Request
 about: Pull Request Template
-title: "[PR] ..."
 ---
 
 **Goals:**

--- a/.github/ISSUE_TEMPLATE/new-pull-request.md
+++ b/.github/ISSUE_TEMPLATE/new-pull-request.md
@@ -1,0 +1,20 @@
+---
+name: New Pull Request
+about: Pull Request Template
+title: "[PR]"
+labels: ''
+assignees: ''
+
+---
+
+**Goals:**
+...
+
+**Is blocked by Issue/s:**
+- ...
+
+**Description:**
+...
+
+**Changes made:**
+- ...

--- a/.github/ISSUE_TEMPLATE/new-pull-request.md
+++ b/.github/ISSUE_TEMPLATE/new-pull-request.md
@@ -2,16 +2,17 @@
 name: New Pull Request
 about: Pull Request Template
 title: "[PR] ..."
-
 ---
 
 **Goals:**
+
 ...
 
 **Is blocked by Issue/s:**
 - ...
 
 **Description:**
+
 ...
 
 **Changes made:**


### PR DESCRIPTION
---
name: Add Issue Templates
about: Adds issue templates to the project
title: "[PR] docs: add-issue-templates"

---

**Goals:**
The goals of this PR is to add issue templates to make filing Bug Reports, Feature Requests and PRs easier.

**Is blocked by Issue/s:**
- none

**Description:**
The files were added to the GitHub folder of the project and can be used when writing issues.

**Changes made:**
- added the template files